### PR TITLE
Add cloudwatch log exports to rds database instance

### DIFF
--- a/rds_database_instance/rds_database_instance.tf
+++ b/rds_database_instance/rds_database_instance.tf
@@ -59,4 +59,5 @@ resource "aws_db_instance" "rds_db_instance" {
   kms_key_id                          = "${lookup(var.optional_parameters, "kms_key_id", "")}"
   iam_database_authentication_enabled = "${lookup(var.optional_parameters, "iam_database_authentication_enabled", false)}"
   tags                                = "${var.db_tags}"
+  enabled_cloudwatch_logs_exports     = ["${var.enabled_cloudwatch_logs_exports}"]
 }

--- a/rds_database_instance/variables.tf
+++ b/rds_database_instance/variables.tf
@@ -49,3 +49,9 @@ variable "subnet_group_tags" {
   description = "A mapping of tags to assign to the resource"
   default     = {}
 }
+
+variable "enabled_cloudwatch_logs_exports" {
+  type        = "list"
+  description = "A list of logs to export to cloudwatch. Possible values are audit, error, general, slowquery"
+  default     = []
+}


### PR DESCRIPTION
Currently this parameter is only supported in the RDS cluster, but it would make sense to support it in instances too.

I have to wonder though... I copy-pasted from the cluster code, but why isn't this in the optional params map instead of its own variable?