### PR TITLE
Fix/mysql user and mysql grant resources dont support empty string for tls option and table

### DIFF
--- a/mysql_schema_configuration/mysql_schema_configuration.tf
+++ b/mysql_schema_configuration/mysql_schema_configuration.tf
@@ -1,6 +1,11 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
+
+locals {
+  user_value = "${var.username}"
+  host       = "%"
+}
 
 resource "mysql_database" "schema" {
   name              = "${var.schema_name}"
@@ -8,27 +13,50 @@ resource "mysql_database" "schema" {
 }
 
 resource "mysql_user" "user" {
-  user = "${var.username}"
+  user = "${local.user_value}"
 
-  host               = "%"
+  host               = "${local.host}"
+  plaintext_password = "${var.password}"
+  count              = "${var.use_tls_option == 0 ? 1 : 0}"
+}
+
+resource "mysql_user" "user_with_tls_option" {
+  user = "${local.user_value}"
+
+  host               = "${local.host}"
   plaintext_password = "${var.password}"
   tls_option         = "${lookup(var.optional_parameters, "tls_option", "")}"
+
+  count = "${var.use_tls_option == 1 ? 1 : 0}"
 }
 
 resource "mysql_grant" "grants" {
   database = "${mysql_database.schema.name}"
 
-  user       = "${mysql_user.user.user}"
-  host       = "${mysql_user.user.host}"
+  user       = "${local.user_value}"
+  host       = "${local.host}"
   privileges = "${var.user_privileges}"
-  table      = "${lookup(var.optional_parameters, "grants_table", "")}"
+  table      = "${lookup(var.optional_parameters, "grants_table", "*")}"
+
+  count      = "${var.use_tls_option == 0 ? 1 : 0}"
+}
+
+resource "mysql_grant" "grants_with_tls_option" {
+  database = "${mysql_database.schema.name}"
+  
+  user       = "${local.user_value}"
+  host       = "${local.host}"
+  privileges = "${var.user_privileges}"
+  table      = "${lookup(var.optional_parameters, "grants_table", "*")}"
   tls_option = "${lookup(var.optional_parameters, "tls_option", "")}"
+
+  count = "${var.use_tls_option == 1 ? 1 : 0}"
 }
 
 resource "aws_ssm_parameter" "username" {
   name  = "${var.parameter_store_path}/Username"
   type  = "${lookup(var.optional_parameters, "username_aws_ssm_parameter_type", "String")}"
-  value = "${mysql_user.user.user}"
+  value = "${local.user_value}"
 
   key_id = "${lookup(var.optional_parameters, "username_kms_key_id", "")}"
 }

--- a/mysql_schema_configuration/mysql_schema_configuration.tf
+++ b/mysql_schema_configuration/mysql_schema_configuration.tf
@@ -2,61 +2,33 @@
  * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
-locals {
-  user_value = "${var.username}"
-  host       = "%"
-}
-
 resource "mysql_database" "schema" {
   name              = "${var.schema_name}"
   default_collation = "utf8_bin"
 }
 
 resource "mysql_user" "user" {
-  user = "${local.user_value}"
+  user = "${var.username}"
 
-  host               = "${local.host}"
+  host               = "%"
   plaintext_password = "${var.password}"
-  count              = "${var.use_tls_option == 0 ? 1 : 0}"
-}
-
-resource "mysql_user" "user_with_tls_option" {
-  user = "${local.user_value}"
-
-  host               = "${local.host}"
-  plaintext_password = "${var.password}"
-  tls_option         = "${lookup(var.optional_parameters, "tls_option", "")}"
-
-  count = "${var.use_tls_option == 1 ? 1 : 0}"
+  tls_option         = "${lookup(var.optional_parameters, "tls_option", "NONE")}"
 }
 
 resource "mysql_grant" "grants" {
   database = "${mysql_database.schema.name}"
 
-  user       = "${local.user_value}"
-  host       = "${local.host}"
+  user       = "${mysql_user.user.user}"
+  host       = "${mysql_user.user.host}"
   privileges = "${var.user_privileges}"
   table      = "${lookup(var.optional_parameters, "grants_table", "*")}"
-
-  count      = "${var.use_tls_option == 0 ? 1 : 0}"
-}
-
-resource "mysql_grant" "grants_with_tls_option" {
-  database = "${mysql_database.schema.name}"
-  
-  user       = "${local.user_value}"
-  host       = "${local.host}"
-  privileges = "${var.user_privileges}"
-  table      = "${lookup(var.optional_parameters, "grants_table", "*")}"
-  tls_option = "${lookup(var.optional_parameters, "tls_option", "")}"
-
-  count = "${var.use_tls_option == 1 ? 1 : 0}"
+  tls_option = "${lookup(var.optional_parameters, "tls_option", "NONE")}"
 }
 
 resource "aws_ssm_parameter" "username" {
   name  = "${var.parameter_store_path}/Username"
   type  = "${lookup(var.optional_parameters, "username_aws_ssm_parameter_type", "String")}"
-  value = "${local.user_value}"
+  value = "${mysql_user.user.user}"
 
   key_id = "${lookup(var.optional_parameters, "username_kms_key_id", "")}"
 }

--- a/mysql_schema_configuration/outputs.tf
+++ b/mysql_schema_configuration/outputs.tf
@@ -3,11 +3,11 @@
  */
 
 output "user" {
-  value = "${local.user_value}"
+  value = "${mysql_user.user.user}"
 }
 
 output "host" {
-  value = "${local.host}"
+  value = "${mysql_user.user.host}"
 }
 
 output "schema_name" {

--- a/mysql_schema_configuration/outputs.tf
+++ b/mysql_schema_configuration/outputs.tf
@@ -1,13 +1,13 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 output "user" {
-  value = "${mysql_user.user.user}"
+  value = "${local.user_value}"
 }
 
 output "host" {
-  value = "${mysql_user.user.host}"
+  value = "${local.host}"
 }
 
 output "schema_name" {

--- a/mysql_schema_configuration/variables.tf
+++ b/mysql_schema_configuration/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 variable "parameter_store_path" {}
@@ -12,6 +12,10 @@ variable "password" {}
 
 variable "password_kms_key_id" {
   default = ""
+}
+
+variable "use_tls_option" {
+  default = 0
 }
 
 variable "optional_parameters" {

--- a/mysql_schema_configuration/variables.tf
+++ b/mysql_schema_configuration/variables.tf
@@ -14,10 +14,6 @@ variable "password_kms_key_id" {
   default = ""
 }
 
-variable "use_tls_option" {
-  default = 0
-}
-
 variable "optional_parameters" {
   type        = "map"
   description = "Parameters with default values. Possible keys are username_aws_ssm_parameter_type and username_kms_key_id; if no key is present default value is used."

--- a/rds_database_cluster/outputs.tf
+++ b/rds_database_cluster/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 output "endpoint" {

--- a/rds_database_cluster/rds_database_cluster.tf
+++ b/rds_database_cluster/rds_database_cluster.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 resource "aws_db_subnet_group" "db_subnet_group" {

--- a/rds_database_cluster/variables.tf
+++ b/rds_database_cluster/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 // Required variables :

--- a/rds_database_instance/outputs.tf
+++ b/rds_database_instance/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 output "endpoint" {

--- a/rds_database_instance/rds_database_instance.tf
+++ b/rds_database_instance/rds_database_instance.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 resource "aws_db_subnet_group" "db_subnet_group" {

--- a/rds_database_instance/variables.tf
+++ b/rds_database_instance/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2017, Coveo Solutions Inc.
+ * Copyright (c) 2011 - 2019, Coveo Solutions Inc.
  */
 
 // Required variables :


### PR DESCRIPTION
Fix default value that were empty to used the real value Terraform use when those parameter are not specified.