### PR TITLE
Add very basic module to create a feature flag in LaunchDarkly

### DIFF
--- a/critical-update/feature-flag.tf
+++ b/critical-update/feature-flag.tf
@@ -1,5 +1,5 @@
 data "launchdarkly_project" "critical-updates" {
-  key = "critical-updates-${var.env}"
+  key = "${var.project-key}"
 }
 
 resource "launchdarkly_feature_flag" "remove-static-queries" {

--- a/critical-update/feature-flag.tf
+++ b/critical-update/feature-flag.tf
@@ -1,0 +1,19 @@
+data "launchdarkly_project" "critical-updates" {
+  key = "critical-updates-${var.env}"
+}
+
+resource "launchdarkly_feature_flag" "remove-static-queries" {
+  project_key = "${data.launchdarkly_project.critical-updates.key}"
+  key = "${var.key}"
+  name = "${var.name}"
+  description = "${var.description}"
+  custom_properties = [{
+    key = "activation-date"
+    name = "Activation Date"
+    value = ["${var.activation_date}"]
+  }, {
+    key = "online-help-url"
+    name = "Online Help URL"
+    value = ["${var.online_help_url}"]
+  }]
+}

--- a/critical-update/feature-flag.tf
+++ b/critical-update/feature-flag.tf
@@ -2,7 +2,7 @@ data "launchdarkly_project" "critical-updates" {
   key = "${var.project-key}"
 }
 
-resource "launchdarkly_feature_flag" "remove-static-queries" {
+resource "launchdarkly_feature_flag" "feature-flag" {
   project_key = "${data.launchdarkly_project.critical-updates.key}"
   key = "${var.key}"
   name = "${var.name}"

--- a/critical-update/variables.tf
+++ b/critical-update/variables.tf
@@ -1,0 +1,19 @@
+variable "key" {
+  description = "The unique key for the critical update."
+}
+
+variable "name" {
+  description = "The name for the critical update (visible to customers)."
+}
+
+variable "description" {
+  description = "Short description of the critical update (visible to customers)."
+}
+
+variable "activation_date" {
+  description = "The date at which we will automatically activate the critical update (YYYY-MM-DD)"
+}
+
+variable "online_help_url" {
+  description = "The URL for the online help topic describing the critical update."
+}

--- a/critical-update/variables.tf
+++ b/critical-update/variables.tf
@@ -1,3 +1,7 @@
+variable "project-key" {
+  description = "The key for the project containing critical updates."
+}
+
 variable "key" {
   description = "The unique key for the critical update."
 }


### PR DESCRIPTION
This just wraps the Terraform provider I've created for Feature Flags in LaunchDarkly. The point here is that "critical updates" are a special kind of flag recognized by the platform, and they need to provide a few mandatory custom properties. Using a module forces users to provide the required data; otherwise a badly formatted feature flag in that project would fill the platform Sentry with errors.