### PR TITLE
Add overridable parameters for default charset and collation

### DIFF
--- a/mysql_schema_configuration/mysql_schema_configuration.tf
+++ b/mysql_schema_configuration/mysql_schema_configuration.tf
@@ -3,8 +3,9 @@
  */
 
 resource "mysql_database" "schema" {
-  name              = "${var.schema_name}"
-  default_collation = "utf8_bin"
+  name                  = "${var.schema_name}"
+  default_character_set = "${lookup(var.optional_parameters, "default_character_set", "utf8")}"
+  default_collation     = "${lookup(var.optional_parameters, "default_collation", "utf8_bin")}"
 }
 
 resource "mysql_user" "user" {


### PR DESCRIPTION
As per https://www.terraform.io/docs/providers/mysql/r/database.html